### PR TITLE
Update deno.json to get the latest version of hono

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
   "imports": {
     "@cross/log": "jsr:@cross/log@^0.10.5",
     "@std/crypto": "jsr:@std/crypto@^1.0.5",
-    "hono": "jsr:@hono/hono@^4.7.5",
+    "hono": "jsr:@hono/hono@^4.7.0",
     "@std/assert": "jsr:@std/assert@1",
     "@std/path": "jsr:@std/path",
     "@std/bytes": "jsr:@std/bytes",


### PR DESCRIPTION
1. After the commit, run: `deno outdated` and test the service.
2. Check `deno.lock` to verify the latest hono is installed
