### PR TITLE
Update fly.toml to enable HSTS

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,9 @@ primary_region = 'sin'
   min_machines_running = 1
   processes = ['app']
 
+[services.ports.http_options.response.headers]
+  Strict-Transport-Security = "max-age=15552000; includeSubDomains; preload"
+
 [[vm]]
   size = "shared-cpu-1x"
   memory = '256mb'


### PR DESCRIPTION
1. Enable HSTS (HTTP Strict Transport Security) in HTTP header
2. Please test before deploying to PROD
3. After deployed in PROD, use SSL test: https://www.ssllabs.com/ssltest/  (for https://api.eg1.io/)