### PR TITLE
Update the .dockerignore file to exclude the Makefile from the container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Ignore all hidden files
 **/.??*
+**/Makefile*
 
 **/*.env
 **/docker-compose*


### PR DESCRIPTION
Do not include Makefile into the container. All 'make' commands must run outside of the container.