### PR TITLE
Update README.md to reflect the new status-codes.jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Since different logistics providers have their own APIs and data formats, integr
 
 ## Scope
 1. This prototype is written in TypeScript and runs on the [Deno runtime](https://deno.com).
-2. We have defined [standard status codes](https://github.com/eagle1-sys/whereis-api-v0/blob/main/metadata/status_codes.jsonc) and consistent format for global logistics data.
+2. We have defined [standard status codes](https://github.com/eagle1-sys/whereis-api-v0/blob/main/metadata/status-codes.jsonc) and consistent format for global logistics data.
 3. Initially it supports two logistics operators: FedEx and SF Express, with a [future roadmap](https://github.com/eagle1-sys/whereis-api-v0/discussions/97) planned. Code review is on [DeepWiki](https://deepwiki.com/eagle1-sys/whereis-api-v0).
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Eagle1 whereis API
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/eagle1-sys/whereis-api-v0)
 
 ## Goal
 **Making it easy** for developers to track any shipment (with any logistics provider), using a simple API query.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Since different logistics providers have their own APIs and data formats, integr
 
 ## Scope
 1. This prototype is written in TypeScript and runs on the [Deno runtime](https://deno.com).
-2. We have defined [standard status codes](https://github.com/eagle1-sys/whereis-api-v0/blob/main/metadata/status-codes.jsonc) and consistent format for global logistics data.
+2. We have defined [standard status codes](metadata/status-codes.jsonc) and a consistent format for global logistics data.
 3. Initially it supports two logistics operators: FedEx and SF Express, with a [future roadmap](https://github.com/eagle1-sys/whereis-api-v0/discussions/97) planned. Code review is on [DeepWiki](https://deepwiki.com/eagle1-sys/whereis-api-v0).
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const response = await fetch(url, {
 
 ---
 
-# Deploying locally using docker containers
+# Getting started
 
 Here’s the gist for deploying Eagle1 locally using Docker containers. For step‑by‑step instructions, see the [How-to Guide](https://github.com/eagle1-sys/whereis-api-v0/wiki/How-to-deploy-locally-using-Docker).
 


### PR DESCRIPTION
status_codes.jsonc is now: status-codes.jsonc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a project badge to the top of the README for quick identification and linking.
  * Updated the reference to the standard status codes to a local path and fixed a minor grammar issue for clarity. No functional or API changes.
  * Renamed the "Deploying locally using docker containers" header to "Getting started" (content unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->