### PR TITLE
Update docker-compose.yaml.sample

### DIFF
--- a/config/docker-compose.yaml.sample
+++ b/config/docker-compose.yaml.sample
@@ -36,8 +36,8 @@ services:
       DB_HOST: whereis-postgres
       DB_USER: whereis_user
       DB_PASSWORD: _CHANGEME_
-      TESTING_URL: http://localhost:8037
-      TESTING_TOKEN: eagle1
+      WHEREIS_API_URL: http://localhost:8037
+      WHEREIS_API_KEY: eagle1
     networks:
       - whereis_net
 networks:

--- a/config/docker-compose.yaml.sample
+++ b/config/docker-compose.yaml.sample
@@ -36,7 +36,7 @@ services:
       DB_HOST: whereis-postgres
       DB_USER: whereis_user
       DB_PASSWORD: _CHANGEME_
-      WHEREIS_API_URL: http://localhost:8037
+      WHEREIS_API_URL: http://whereis-api-v0:8037
       WHEREIS_API_KEY: eagle1
     networks:
       - whereis_net


### PR DESCRIPTION
Use the confirmed variable names:
`WHEREIS_API_KEY, WHEREIS_API_URL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated Docker Compose sample to use WHEREIS_API_URL and WHEREIS_API_KEY in place of TESTING_URL and TESTING_TOKEN; default API URL now points to the service host rather than localhost.
- Chores
  - Standardized environment variable names for the whereis API service; update any integrations or local setups to match the new variable names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->