### PR TITLE
Change statusCode 3250 to "In-Transit to Destination"

### DIFF
--- a/metadata/status-codes.jsonc
+++ b/metadata/status-codes.jsonc
@@ -21,7 +21,7 @@
   "3100": "Received by Carrier",                    // major
   "3150": "Customs Clearance: Export In-Progress",  // minor
   "3200": "Customs Clearance: Export Released",     // major
-  "3250": "In-Transit",                             // minor
+  "3250": "In-Transit to Destination",              // minor
   "3300": "Arrived At Destination",                 // major
   "3350": "Customs Clearance: Import In-Progress",  // minor
   "3400": "Customs Clearance: Import Released",     // major

--- a/metadata/status-codes.jsonc
+++ b/metadata/status-codes.jsonc
@@ -22,7 +22,7 @@
   "3150": "Customs Clearance: Export In-Progress",  // minor
   "3200": "Customs Clearance: Export Released",     // major
   "3250": "In-Transit to Destination",              // minor
-  "3300": "Arrived At Destination",                 // major
+  "3300": "Arrived at Destination",                 // major
   "3350": "Customs Clearance: Import In-Progress",  // minor
   "3400": "Customs Clearance: Import Released",     // major
   "3450": "Final Delivery In-Progress",             // minor


### PR DESCRIPTION
Make 3250 more descriptive than just "In-Transit"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Renamed status 3250 to “In-Transit to Destination” for clearer, more specific messaging across dashboards, reports, and notifications.
  * Normalized capitalization of status 3300 to “Arrived at Destination” for consistent wording.
  * Wording-only changes with no impact on functionality, workflows, or integrations; improves clarity for users tracking deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->