### PR TITLE
Bugfix: Revise the test code to handle the expired waybill

### DIFF
--- a/metadata/error-codes.jsonc
+++ b/metadata/error-codes.jsonc
@@ -13,7 +13,6 @@
   "403-01": "Forbidden: The provided Whereis API key is not authorized for this request.",
 
   "404-01": "Whereis API could not retrieve tracking information from the data source provider.",
-  "404-02": "The tracking number has expired with the data source provider.",
 
   "429-01": "Too many requests.",
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Retired the dedicated error code for expired tracking numbers (previously 404-02).
  - Expired or unavailable tracking scenarios now appear under standard 404-style messaging for consistent error presentation.
  - No functional changes; only the specific code label is removed from display and documentation, reducing redundant error variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->