### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/main/scheduler.ts
+++ b/src/main/scheduler.ts
@@ -89,7 +89,7 @@ async function syncRoutes() {
     // Group tracking numbers by operator
     const groupedTrackingNums = groupTrackingNumsByOperator(inProcessTrackingNums);
     for (const [operator, trackingNums] of Object.entries(groupedTrackingNums)) {
-      const batchSize = OperatorRegistry.getBatchSize(operator)
+      const batchSize = OperatorRegistry.getBatchSize(operator);
       if (batchSize <= 0) {
         logger.error(`${whereIsAPI("exception")} Invalid batch size for operator ${operator}, skipping`);
         continue;


### PR DESCRIPTION
Add an explicit semicolon to the variable declaration on line 92 in `src/main/scheduler.ts` so semicolon usage is consistent with the enclosing function.

Best fix (without changing functionality):
- In `syncRoutes()`, change:
  - `const batchSize = OperatorRegistry.getBatchSize(operator)`
  - to `const batchSize = OperatorRegistry.getBatchSize(operator);`
- No imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-visible changes. Internal code maintenance was performed to improve code consistency and quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->