### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -5,6 +5,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
Potential fix for [https://github.com/eagle1-sys/whereis-api-v0/security/code-scanning/1](https://github.com/eagle1-sys/whereis-api-v0/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (best at root level here, since there is one job) to enforce least privilege for `GITHUB_TOKEN`.  
For this workflow, `actions/checkout` requires `contents: read`; no write scopes are needed for the shown steps.

**Change to make:**
- File: `.github/workflows/fly.yml`
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
