### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/db/dbutil.ts
+++ b/src/db/dbutil.ts
@@ -43,7 +43,7 @@ export async function initConnection() {
 async function initPgConnection() : Promise<postgres.Sql> {
   let sql: postgres.Sql;
   const dbHost = Deno.env.get("DB_HOST");
-  const dbPort = Number(Deno.env.get("DB_PORT") ?? "5432")
+  const dbPort = Number(Deno.env.get("DB_PORT") ?? "5432");
   if (!dbHost) {
     throw new AppError("500-01", `ERR-DBUTIL-A - DB_HOST environment variable is not set.`);
   }


### PR DESCRIPTION
To fix this, make semicolon usage consistent with the surrounding function by adding an explicit semicolon at the end of line 46 in `src/db/dbutil.ts`.

Best single fix (no functionality change):
- In `initPgConnection`, change:
  - `const dbPort = Number(Deno.env.get("DB_PORT") ?? "5432")`
  - to `const dbPort = Number(Deno.env.get("DB_PORT") ?? "5432");`

No imports, methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._