### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/src/connectors/operator/sfex.ts
+++ b/src/connectors/operator/sfex.ts
@@ -296,7 +296,7 @@ export class Sfex implements OperatorModule {
       throw new AppError("500-02", `ERR-SFEX-F - getRoute(${response.status})`);
     }
 
-    return await getResponseJSON(response, "ERR-SFEX-G - getRoute")
+    return await getResponseJSON(response, "ERR-SFEX-G - getRoute");
   }
 
   /**


### PR DESCRIPTION
To fix this, make statement termination consistent by adding an explicit semicolon at the end of the return statement on line 299 in `src/connectors/operator/sfex.ts`.

Best single fix (no behavior change):
- In `getRoute(...)`, change:
  - `return await getResponseJSON(response, "ERR-SFEX-G - getRoute")`
  - to
  - `return await getResponseJSON(response, "ERR-SFEX-G - getRoute");`

No imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._