### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -404,12 +404,13 @@ app.get("/web-health", (c: Context) => {
  * GET /app-health - App health check endpoint
  */
 app.get("/app-health", async (c: Context) => {
-  if (getDbClient() === undefined) {
+  const dbClient = getDbClient();
+  if (!dbClient) {
     logger.info(`${whereIsAPI("startup")} DB connection is not ready`);
     return c.text("INIT", 200);
   }
   // Test the connection by executing a simple query
-  const testResult = await getDbClient().ping();
+  const testResult = await dbClient.ping();
   if (testResult) {
     return c.text("UP", 200);
   }


### PR DESCRIPTION
To fix this without changing intended behavior, store `getDbClient()` in a local variable and perform a truthiness guard on that variable before calling `.ping()`. This avoids the invalid strict comparison against `undefined`, avoids multiple calls to `getDbClient()`, and keeps the existing `"INIT"` / `"UP"` / `"DOWN"` responses.

In `src/main/server.ts`, inside the `/app-health` route (around lines 406–413), replace:
- `if (getDbClient() === undefined) { ... }`
- `const testResult = await getDbClient().ping();`

with:
- `const dbClient = getDbClient();`
- `if (!dbClient) { ... }`
- `const testResult = await dbClient.ping();`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._