### PR TITLE
Fix for Unneeded defensive code for server.ts

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -543,11 +543,11 @@ function parseURL(req: HonoRequest): [TrackingID, Record<string, string>, Record
   return [trackingID, extraParams, queryParams];
 }
 
-function validateQueryParams(params: Record<string, string>, validParams?: Set<string>,): string[] {
+function validateQueryParams(params: Record<string, string>, validParams: Set<string>): string[] {
   const invalidParams: string[] = [];
 
   Object.keys(params).forEach((key) => {
-    if (validParams === undefined || !validParams.has(key)) {
+    if (!validParams.has(key)) {
       invalidParams.push(key);
     }
   });


### PR DESCRIPTION
General fix: remove unreachable defensive checks by tightening function contracts to reflect actual usage.

Best fix here without changing functionality:
- In `src/main/server.ts`, update `validateQueryParams` so `validParams` is required instead of optional.
- Remove the `validParams === undefined` branch from the condition, leaving only membership validation.
- No import or dependency changes are needed.

This preserves behavior for all currently shown calls (which always pass a `Set`) and resolves the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._