### PR TITLE
Potential fix for code scanning alert no. 2: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/db/api_key.ts
+++ b/src/db/api_key.ts
@@ -58,12 +58,27 @@ function generateApiKey(length: number = 48): string {
   const chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-  // Generate random bytes and map to alphanumeric characters
-  const randomBytes = crypto.getRandomValues(new Uint8Array(length));
-  const key = Array.from(randomBytes)
-    .map((byte) => chars[byte % chars.length])
-    .join("");
-  return `sk-${key}`;
+  // Use rejection sampling to avoid modulo bias when mapping random bytes to characters.
+  const maxUnbiased = Math.floor(256 / chars.length) * chars.length;
+  const keyChars: string[] = [];
+
+  while (keyChars.length < length) {
+    const randomBytes = crypto.getRandomValues(
+      new Uint8Array(length - keyChars.length),
+    );
+
+    for (const byte of randomBytes) {
+      if (byte >= maxUnbiased) {
+        continue;
+      }
+      keyChars.push(chars[byte % chars.length]);
+      if (keyChars.length === length) {
+        break;
+      }
+    }
+  }
+
+  return `sk-${keyChars.join("")}`;
 }
 
 // Execute the main function and handle any uncaught errors


### PR DESCRIPTION
Potential fix for [https://github.com/eagle1-sys/whereis-api-v0/security/code-scanning/2](https://github.com/eagle1-sys/whereis-api-v0/security/code-scanning/2)

To fix this without changing functionality, keep the same character set and output format (`sk-` prefix + alphanumeric body), but replace `% chars.length` with rejection sampling:

- Generate random bytes.
- Accept only bytes `< maxUnbiased`, where `maxUnbiased = floor(256 / chars.length) * chars.length` (for 62, this is 248).
- Map accepted bytes with `% chars.length`.
- Continue until `length` characters are produced.

This removes modulo bias while preserving API behavior and character distribution uniformity.

In `src/db/api_key.ts`, only update `generateApiKey` (lines 57–67 region). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
