### PR TITLE
Fix for Useless conditional in main.ts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,8 +107,6 @@ async function monitorAndRestartScheduler() {
   while (!shuttingDown) {
     const status = await schedulerCmd.status;
 
-    if (shuttingDown) break;
-
     if (status.success) {
       logger.info("[main] Scheduler exited normally, not restarting.");
       break;


### PR DESCRIPTION
General fix approach: remove or refactor conditional checks that static analysis proves constant in a path, while keeping shutdown behavior intact via remaining guards.

Best fix here: remove the redundant `if (shuttingDown) break;` at line 110. The loop already checks `while (!shuttingDown)`, and there is another shutdown guard at line 123 before restarting the scheduler. So behavior remains effectively unchanged: during shutdown, restart still won’t occur. This is a minimal, safe change in `src/main/main.ts` inside `monitorAndRestartScheduler()`.

No imports, new methods, or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal scheduler monitoring logic for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->