### PR TITLE
optimize fdx for status 3300

### DIFF
--- a/src/connectors/operator/fdx.ts
+++ b/src/connectors/operator/fdx.ts
@@ -56,18 +56,20 @@ export class Fdx implements OperatorModule {
       AR: function (_entity: Entity, sourceData: Record<string, unknown>): number {
         const locationType = sourceData["locationType"] as string;
         const eventDescription = sourceData["eventDescription"] as string;
-        if (_entity.additional.isCrossBorder) {
-          if (locationType === "DESTINATION_FEDEX_FACILITY" ||
-              (locationType === "SORT_FACILITY" && /destination/i.test(eventDescription))) {
-            return 3300;            // At destination sort facility
-          }
 
-          // Check for arrival in the destination country for cross-border shipments
+        // This applies to all shipments
+        if (locationType === "DESTINATION_FEDEX_FACILITY" ||
+            (locationType === "SORT_FACILITY" && /destination/i.test(eventDescription))) {
+          return 3300;  // At destination sort facility
+        }
+
+        // Check for arrival in the destination country for cross-border shipments
+        if (_entity.additional.isCrossBorder) {
           const scanLocation = sourceData["scanLocation"] as Record<string, unknown> | null;
           const destAddress = _entity.additional.destination as string | undefined;
           const destCountryName = scanLocation?.["countryName"] as string | undefined;
           if (/arrived/i.test(eventDescription) && destAddress && destCountryName && destAddress.endsWith(destCountryName)) {
-            return 3300; // Arrived at Destination
+            return 3300;  // Arrived at Destination
           }
         }
 


### PR DESCRIPTION
Modify the FedEx conditions for status 3300, which indicates that the shipment has arrived at its destination.
- Any shipment that has been marked as “arrived at destination” by FedEx.
- Any cross-border shipment where the destination country matches the specified country.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FedEx tracking status handling so destination facility and destination sort-facility scans consistently report status `3300` for all shipments.
  * Preserved existing cross-border arrival-country detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->